### PR TITLE
Fixes encrypted-links plugin

### DIFF
--- a/nixops_encrypted_links/plugin.py
+++ b/nixops_encrypted_links/plugin.py
@@ -38,11 +38,7 @@ class NixopsEncryptedLinksPlugin(Plugin):
 
     @staticmethod
     def load():
-        return [
-            "nixops_aws.resources",
-            "nixops_aws.backends.ec2",
-            "nixops_aws.resources.ec2_keypair",
-        ]
+        return []
 
 
 @nixops.plugins.hookimpl


### PR DESCRIPTION
* Fixes the encrypted-links plugin from a few bugs
* Also requires a small PR upstream fix to nixops -- see PR https://github.com/NixOS/nixops/pull/1430
* Tested successfully with:
  * nixops-aws (current master),
  * nixops-packet (current master), 
  * nixops-vbox (current master),
  * nixops-libvirtd (current master),
  * nixops-gce (current master)